### PR TITLE
Fixed test trace sampling bug and updated recency constant 

### DIFF
--- a/park/envs/cache/cache.py
+++ b/park/envs/cache/cache.py
@@ -55,9 +55,6 @@ class TraceSrc(object):
         done = (self.req + 1) >= self.n_request
         return obs, done
 
-    def trace_done(self):
-        return done 
-
 class CacheSim(object):
     def __init__(self, cache_size, policy, action_space, state_space):
         # invariant
@@ -83,7 +80,6 @@ class CacheSim(object):
         self.cache = defaultdict(list)  # requested items with caching
         self.cache_pq = []
         self.cache_remain = self.cache_size
-        self.last_req_time_dict = {}
         self.count_ohr = 0
         self.count_bhr = 0
         self.size_all = 0
@@ -94,7 +90,6 @@ class CacheSim(object):
         self.cache = defaultdict(list)
         self.cache_pq = []
         self.cache_remain = self.cache_size
-        self.last_req_time_dict = {}
         self.count_ohr = 0
         self.count_bhr = 0
         self.size_all = 0
@@ -105,16 +100,6 @@ class CacheSim(object):
         cache_size_online_remain = self.cache_remain
         discard_obj_if_admit = []
         obj_time, obj_id, obj_size = obj[0], obj[1], obj[2]
-
-
-        # Initialize the last request time
-        try:
-            self.last_req_time_dict[obj_id] = req - self.cache[obj[1]][1]
-        except IndexError:
-            try:
-                self.last_req_time_dict[obj_id] = req - self.non_cache[obj[1]][1]
-            except IndexError:
-                self.last_req_time_dict[obj_id] = 500
 
         # create the current state for cache simulator
         cost = 0
@@ -196,7 +181,10 @@ class CacheSim(object):
 
     def get_state(self, obj=[0, 0, 0, 0]):
         '''
-        Return the state of the object,  [obj_size, cache_size_online_remain, self.last_req_time_dict[obj_id]]
+        Return the state of the object,  [obj_size, cache_size_online_remain, recency (steps since object was last visited) = req - last visited time]
+        If an object has never been seen before, assigned a constant for the recency feature.
+        For more information, see Learning Caching Policies with Subsampling:
+            http://mlforsystems.org/assets/papers/neurips2019/learning_wang_2019.pdf
         '''
         obj_time, obj_id, obj_size = obj[0], obj[1], obj[2]
         try:
@@ -205,7 +193,8 @@ class CacheSim(object):
             try:
                 req = self.req - self.non_cache[obj_id][1]
             except IndexError:
-                req = 500
+                # Unseen objects (not in non_cache or cache) are assigned this recency constant
+                req = config.cache_unseen_recency
         state = [obj_size, self.cache_remain, req]
 
         return state
@@ -252,7 +241,7 @@ class CacheEnv(core.Env):
         # reset environment (generate new jobs)
         self.reset(1, 2)
 
-    def reset(self, low=1, high=1001):
+    def reset(self, low=0, high=1000):
         new_trace = self.np_random.randint(low, high)
         self.src.reset(new_trace)
         self.sim.reset()

--- a/park/param.py
+++ b/park/param.py
@@ -103,6 +103,8 @@ parser.add_argument('--cache_trace', type=str, required=False, default='test',
                     help='trace selection')
 parser.add_argument('--cache_size', type=int, required=False, default=1024, 
                     help='size of network cache')
+parser.add_argument('--cache_unseen_recency', type=int, required=False, default=500,
+                    help='default number for the recency feature')
 
 # -- Simple Queue --
 parser.add_argument('--sq_num_servers', type=float, default=5,

--- a/park/unittest/test_cache.py
+++ b/park/unittest/test_cache.py
@@ -1,11 +1,34 @@
 import unittest
 from park.unittest.run_env import run_env_with_random_agent
-
+import park
+from park.param import config
 
 class TestCache(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.env_name = 'cache'
+
+    def test_trace_recency(self):
+        # Ensure that config for unseen recency is passed to unseen items, first observation will always be unseen
+        env = park.make('cache')
+        config.cache_unseen_recency = 1000
+        obs = env.reset()
+        self.assertTrue(obs[2] == 1000)
+
+        config.cache_unseen_recency = 500
+        obs = env.reset()
+        self.assertTrue(obs[2] == 500)
+
+    @unittest.expectedFailure
+    def test_bounds(self):
+        # New upper bound for the cache test traces, test trace numbers end at 999
+        env = park.make('cache')
+        env.reset(low=1000, high=1001)
+
+    def test_bounds_low(self):
+        # New lower bound for the cache test traces, test trace numbers start at 0
+        env = park.make('cache')
+        env.reset(low=0, high=1)
 
     def test_run_env_n_times(self, n=10):
         for _ in range(n):


### PR DESCRIPTION
- Fixed trace sampling bug. Test traces are numbered from 0 to 999, and sampling currently pulls values from 1 to 1000, causing it to crash. Simple bug to fix, I added unit tests to check the bounds - but they might just be extra clutter
- Added config.cache_unseen_recency as a configurable parameter. Constant was previously hardcoded to be 500. Added unit tests to ensure that this works properly
- Removed the trace_done function - this is not being used
- Removed the last_req_time_dict - this is also not being used at all and I thought it was confusing when trying to understand the code - let me know if you think it should stay. The computation for recency is done underneath get_state()